### PR TITLE
공공 데이터 API에서 데이터를 조회한다.

### DIFF
--- a/src/main/java/towardssweetly/datascheduler/DataSchedulerApplication.java
+++ b/src/main/java/towardssweetly/datascheduler/DataSchedulerApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class DataSchedulerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(DataSchedulerApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(DataSchedulerApplication.class, args);
+    }
 
 }

--- a/src/main/java/towardssweetly/datascheduler/config/CustomItemDeserializer.java
+++ b/src/main/java/towardssweetly/datascheduler/config/CustomItemDeserializer.java
@@ -1,0 +1,54 @@
+package towardssweetly.datascheduler.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import towardssweetly.datascheduler.infra.dto.FoodNtrIrdntInfoField;
+import towardssweetly.datascheduler.infra.dto.FoodNtrIrdntInfoResponseItem;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+import static towardssweetly.datascheduler.infra.dto.FoodNtrIrdntInfoField.*;
+
+/**
+ * {@link FoodNtrIrdntInfoResponseItem} 역직렬화를 위한 클래스.
+ * Double 필드에 N/A 문자열이 입력되는 문제를 해결한다.
+ */
+public class CustomItemDeserializer extends JsonDeserializer<FoodNtrIrdntInfoResponseItem> {
+    @Override
+    public FoodNtrIrdntInfoResponseItem deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        var node = (JsonNode) p.getCodec().readTree(p);
+        return new FoodNtrIrdntInfoResponseItem(
+                getField(node, NAME).asText(),
+                parseDouble(getField(node, SERVING_SIZE_GRAM)),
+                parseDouble(getField(node, CALORIES_KCAL)),
+                parseDouble(getField(node, CARBOHYDRATES_GRAM)),
+                parseDouble(getField(node, PROTEIN_GRAM)),
+                parseDouble(getField(node, FAT_GRAM)),
+                parseDouble(getField(node, SUGARS_GRAM)),
+                parseDouble(getField(node, SODIUM_MILLI_GRAM)),
+                parseDouble(getField(node, CHOLESTRAOL_MILLI_GRAM)),
+                parseDouble(getField(node, SATURATED_FATTY_ACIDS_GRAM)),
+                parseDouble(getField(node, TRANS_FATTY_ACIDS_GRAM)),
+                parseYear(getField(node, BEGIN_YEAR)),
+                getField(node, MANUFACTURER).asText()
+        );
+    }
+
+    private static JsonNode getField(JsonNode node, FoodNtrIrdntInfoField field) {
+        return node.get(field.getValue());
+    }
+
+    private Double parseDouble(JsonNode node) {
+        if ("N/A".equals(node.asText())) {
+            return null;
+        }
+        return node.asDouble();
+    }
+
+    private LocalDate parseYear(JsonNode bgnYear) {
+        return LocalDate.of(Integer.parseInt(bgnYear.asText()), 1, 1);
+    }
+}

--- a/src/main/java/towardssweetly/datascheduler/config/RestTemplateBuilderConfiguration.java
+++ b/src/main/java/towardssweetly/datascheduler/config/RestTemplateBuilderConfiguration.java
@@ -1,0 +1,21 @@
+package towardssweetly.datascheduler.config;
+
+import org.springframework.boot.autoconfigure.web.client.RestTemplateBuilderConfigurer;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * {@link org.springframework.web.client.RestTemplate} 을 사용할 때,ConnectTimeout 과 ReadTimeout 을 설정해 병목 현상 빈도를 최소화한다.
+ */
+@Configuration(proxyBeanMethods = false)
+public class RestTemplateBuilderConfiguration {
+    @Bean
+    public RestTemplateBuilder restTemplateBuilder(RestTemplateBuilderConfigurer configurer) {
+        return configurer.configure(new RestTemplateBuilder())
+                .setConnectTimeout(Duration.ofSeconds(7))
+                .setReadTimeout(Duration.ofSeconds(4));
+    }
+}

--- a/src/main/java/towardssweetly/datascheduler/infra/FoodNtrIrdntInfoService.java
+++ b/src/main/java/towardssweetly/datascheduler/infra/FoodNtrIrdntInfoService.java
@@ -1,0 +1,48 @@
+package towardssweetly.datascheduler.infra;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import towardssweetly.datascheduler.infra.dto.FoodNtrIrdntInfoResponse;
+
+/**
+ * <a href="https://www.data.go.kr/tcs/dss/selectApiDataDetailView.do?publicDataPk=15057436">식품의약품안전처_식품 영양성분 정보</a>에서 데이터를 추출한다.
+ * <h3>요청</h3>
+ * API를 요청할 때, 전달해야할 파라미터는 페이지 번호, 한 페이지 결과 수, 인증키(공공데이터포털에서 발급받은 인증키), 데이터 포맷(응답데이터 형식(xml/json))이다.
+ * <h3>응답</h3>
+ * API 응답 결과에는 결과코드, 결과메시지, 한 페이지 결과수, 페이지 번호, 전체 결과 수, 식품이름, 1회제공량 (g), 열량 (kcal), 탄수화물 (g),
+ * 단백질 (g), 지방 (g), 당류 (g), 나트륨 (mg), 콜레스테롤 (mg), 포화지방산 (g), 트랜스지방산 (g) 정보가 포함된다.
+ * <h3>주의할 점</h3>
+ * 응답으로 반환되는 파라미터 필드명이 <strong>NUTR_CONT*</strong>로 표기되어 혼동할 수 있으니 주의하자.
+ */
+@Service
+public class FoodNtrIrdntInfoService {
+    private static final String URL = "https://apis.data.go.kr/1471000/FoodNtrIrdntInfoService1/getFoodNtrItdntList1";
+    private final RestTemplate restTemplate;
+
+    public FoodNtrIrdntInfoService(RestTemplateBuilder builder) {
+        this.restTemplate = builder.build();
+    }
+
+    public FoodNtrIrdntInfoResponse getData(int pageNo, int numOfRows, String type, String serviceKey) {
+        final var uri = UriComponentsBuilder.fromUriString(URL)
+                .queryParam("pageNo", pageNo)
+                .queryParam("serviceKey", serviceKey)
+                .queryParam("numOfRows", numOfRows)
+                .queryParam("type", type)
+                .encode()
+                .build()
+                .toUri();
+
+        final var requestEntity = RequestEntity
+                .get(uri)
+                .accept(MediaType.APPLICATION_JSON)
+                .build();
+
+        return restTemplate.exchange(requestEntity, FoodNtrIrdntInfoResponse.class)
+                .getBody();
+    }
+}

--- a/src/main/java/towardssweetly/datascheduler/infra/FoodNtrIrdntInfoService.java
+++ b/src/main/java/towardssweetly/datascheduler/infra/FoodNtrIrdntInfoService.java
@@ -27,7 +27,7 @@ public class FoodNtrIrdntInfoService {
         this.restTemplate = builder.build();
     }
 
-    public FoodNtrIrdntInfoResponse getData(int pageNo, int numOfRows, String type, String serviceKey) {
+    public FoodNtrIrdntInfoResponse getFoodNtrIrdntInfoResponse(int pageNo, int numOfRows, String type, String serviceKey) {
         final var uri = UriComponentsBuilder.fromUriString(URL)
                 .queryParam("pageNo", pageNo)
                 .queryParam("serviceKey", serviceKey)

--- a/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoField.java
+++ b/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoField.java
@@ -1,0 +1,27 @@
+package towardssweetly.datascheduler.infra.dto;
+
+public enum FoodNtrIrdntInfoField {
+    NAME("DESC_KOR"),
+    SERVING_SIZE_GRAM("SERVING_WT"),
+    CALORIES_KCAL("NUTR_CONT1"),
+    CARBOHYDRATES_GRAM("NUTR_CONT2"),
+    PROTEIN_GRAM("NUTR_CONT3"),
+    FAT_GRAM("NUTR_CONT4"),
+    SUGARS_GRAM("NUTR_CONT5"),
+    SODIUM_MILLI_GRAM("NUTR_CONT6"),
+    CHOLESTRAOL_MILLI_GRAM("NUTR_CONT7"),
+    SATURATED_FATTY_ACIDS_GRAM("NUTR_CONT8"),
+    TRANS_FATTY_ACIDS_GRAM("NUTR_CONT9"),
+    BEGIN_YEAR("BGN_YEAR"),
+    MANUFACTURER("ANIMAL_PLANT");
+
+    private final String value;
+
+    FoodNtrIrdntInfoField(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoResponse.java
+++ b/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoResponse.java
@@ -1,14 +1,11 @@
 package towardssweetly.datascheduler.infra.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString
 public class FoodNtrIrdntInfoResponse {
-    @JsonProperty("header")
     private FoodNtrIrdntInfoResponseHeader header;
-    @JsonProperty("body")
     private FoodNtrIrdntInfoResponseBody body;
 }

--- a/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoResponse.java
+++ b/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoResponse.java
@@ -1,0 +1,14 @@
+package towardssweetly.datascheduler.infra.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class FoodNtrIrdntInfoResponse {
+    @JsonProperty("header")
+    private FoodNtrIrdntInfoResponseHeader header;
+    @JsonProperty("body")
+    private FoodNtrIrdntInfoResponseBody body;
+}

--- a/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoResponseBody.java
+++ b/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoResponseBody.java
@@ -11,10 +11,8 @@ import java.util.List;
 public class FoodNtrIrdntInfoResponseBody {
     @JsonProperty("pageNo")
     private int pageNumber;
-    @JsonProperty("totalCount")
     private int totalCount;
     @JsonProperty("numOfRows")
     private int count;
-    @JsonProperty("items")
     private List<FoodNtrIrdntInfoResponseItem> items;
 }

--- a/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoResponseBody.java
+++ b/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoResponseBody.java
@@ -1,0 +1,20 @@
+package towardssweetly.datascheduler.infra.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+public class FoodNtrIrdntInfoResponseBody {
+    @JsonProperty("pageNo")
+    private int pageNumber;
+    @JsonProperty("totalCount")
+    private int totalCount;
+    @JsonProperty("numOfRows")
+    private int count;
+    @JsonProperty("items")
+    private List<FoodNtrIrdntInfoResponseItem> items;
+}

--- a/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoResponseHeader.java
+++ b/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoResponseHeader.java
@@ -1,0 +1,14 @@
+package towardssweetly.datascheduler.infra.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class FoodNtrIrdntInfoResponseHeader {
+    @JsonProperty("resultCode")
+    private int code;
+    @JsonProperty("resultMsg")
+    private String message;
+}

--- a/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoResponseItem.java
+++ b/src/main/java/towardssweetly/datascheduler/infra/dto/FoodNtrIrdntInfoResponseItem.java
@@ -1,0 +1,24 @@
+package towardssweetly.datascheduler.infra.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import towardssweetly.datascheduler.config.CustomItemDeserializer;
+
+import java.time.LocalDate;
+
+@JsonDeserialize(using = CustomItemDeserializer.class)
+public record FoodNtrIrdntInfoResponseItem(
+        String name,
+        Double servingSizeGram,
+        Double caloriesKcal,
+        Double carbohydratesGram,
+        Double proteinGram,
+        Double fatGram,
+        Double sugarsGram,
+        Double sodiumMilligram,
+        Double cholesterolMilligram,
+        Double saturatedFattyAcidsGram,
+        Double transFattyAcidsGram,
+        LocalDate beginYear,
+        String manufacturer
+) {
+}

--- a/src/test/java/towardssweetly/datascheduler/infra/FoodNtrIrdntInfoServiceTest.java
+++ b/src/test/java/towardssweetly/datascheduler/infra/FoodNtrIrdntInfoServiceTest.java
@@ -1,0 +1,21 @@
+package towardssweetly.datascheduler.infra;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+
+class FoodNtrIrdntInfoServiceTest {
+    private static final String SERVICE_KEY = "1cM0fca7x9v9lVDH7x/Ys0Sg9uzmVsLqRY/yRtnbxpefDmZHVQf2zdR768cNW8Qrx5GlwWK0RyMa2ekGH4bJSg==";
+    private final FoodNtrIrdntInfoService foodNtrIrdntInfoService = new FoodNtrIrdntInfoService(new RestTemplateBuilder());
+
+    @Test
+    @DisplayName("https://apis.data.go.kr 주소에 실제 데이터를 요청한다.")
+    void getDataTest() {
+        final String json = "json";
+        final int pageNo = 1;
+        final int numOfRows = 10;
+        var response = foodNtrIrdntInfoService.getData(pageNo, numOfRows, json, SERVICE_KEY);
+        Assertions.assertThat(response.getBody().getItems().size()).isEqualTo(numOfRows);
+    }
+}

--- a/src/test/java/towardssweetly/datascheduler/infra/FoodNtrIrdntInfoServiceTest.java
+++ b/src/test/java/towardssweetly/datascheduler/infra/FoodNtrIrdntInfoServiceTest.java
@@ -5,17 +5,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 
+import static org.assertj.core.api.Assertions.*;
+
 class FoodNtrIrdntInfoServiceTest {
     private static final String SERVICE_KEY = "1cM0fca7x9v9lVDH7x/Ys0Sg9uzmVsLqRY/yRtnbxpefDmZHVQf2zdR768cNW8Qrx5GlwWK0RyMa2ekGH4bJSg==";
     private final FoodNtrIrdntInfoService foodNtrIrdntInfoService = new FoodNtrIrdntInfoService(new RestTemplateBuilder());
 
     @Test
     @DisplayName("https://apis.data.go.kr 주소에 실제 데이터를 요청한다.")
-    void getDataTest() {
-        final String json = "json";
-        final int pageNo = 1;
-        final int numOfRows = 10;
-        var response = foodNtrIrdntInfoService.getData(pageNo, numOfRows, json, SERVICE_KEY);
-        Assertions.assertThat(response.getBody().getItems().size()).isEqualTo(numOfRows);
+    void getFoodNtrIrdntInfoResponseTest() {
+        final var json = "json";
+        final var pageNo = 1;
+        final var numOfRows = 10;
+        final var response = foodNtrIrdntInfoService.getFoodNtrIrdntInfoResponse(pageNo, numOfRows, json, SERVICE_KEY);
+        assertThat(response.getBody().getItems().size()).isEqualTo(numOfRows);
     }
 }


### PR DESCRIPTION
## 작업에 대한 간단한 요약

공공 데이터에서 필요한 데이터를 추출한다.

### 변경내역

- 공공 데이터에서 데이터를 조회한다.
- 공공 데이터에서 제공하는 데이터 10개를 조회하는 테스트를 구성한다.

### 어떤부분에 집중해서 리뷰하면좋을지

#### 서비스 키 관리 이슈

서비스 키를 외부에서 관리해야 하지만 필드에 들어간 문제가 있다.

#### 공공 데이터 API 필드 관리

유사한 이름의 필드 값을 가져올 때 코드 실수가 최대한 없앨 수 있도록 ENUM 을 활용할 필요가 있었다.

```java
public enum FoodNtrIrdntInfoField {  
  NAME("DESC_KOR"),  
  SERVING_SIZE_GRAM("SERVING_WT"),  
  CALORIES_KCAL("NUTR_CONT1"),  
  CARBOHYDRATES_GRAM("NUTR_CONT2"),

  ...

}
```

**AS-IS**

```java
return new FoodNtrIrdntInfoResponseItem(  
	node.get("DESC_KOR").asText(),  
	parseDouble(node.get("SERVING_WT")),  
	parseDouble(node.get("NUTR_CONT1")),  
	parseDouble(node.get("NUTR_CONT2")),  
	parseDouble(node.get("NUTR_CONT3")),  
	parseDouble(node.get("NUTR_CONT4")),  
	parseDouble(node.get("NUTR_CONT5")),  
	parseDouble(node.get("NUTR_CONT6")),  
	parseDouble(node.get("NUTR_CONT7")),  
	parseDouble(node.get("NUTR_CONT8")),  
	parseDouble(node.get("NUTR_CONT9")),  
	parseYear(node.get("BGN_YEAR")),  
	node.get("ANIMAL_PLANT").asText()
);
```

**TO-BE**

어떤 필드에 어떤 값이 들어가는지를 쉽게 확인해 휴먼 에러를 최소화했다.

```java
return new FoodNtrIrdntInfoResponseItem(  
	getField(node, NAME).asText(),  
	parseDouble(getField(node, SERVING_SIZE_GRAM)),  
	parseDouble(getField(node, CALORIES_KCAL)),  
	parseDouble(getField(node, CARBOHYDRATES_GRAM)),  
	parseDouble(getField(node, PROTEIN_GRAM)),  
	parseDouble(getField(node, FAT_GRAM)),  
	parseDouble(getField(node, SUGARS_GRAM)),  
	parseDouble(getField(node, SODIUM_MILLI_GRAM)),  
	parseDouble(getField(node, CHOLESTRAOL_MILLI_GRAM)),  
	parseDouble(getField(node, SATURATED_FATTY_ACIDS_GRAM)),  
	parseDouble(getField(node, TRANS_FATTY_ACIDS_GRAM)),  
	parseYear(getField(node, BEGIN_YEAR)),  
	getField(node, MANUFACTURER).asText()  
);
```

#### `JsonDeserializer`를 구현한 직접 파싱

응답 값 데이터 무결성이 지켜지지 않아 Double 자료구조 역직렬화가 진행되지 않았고, `N/A` 필드를 null 로 변경할 수 있는 수단이 필요했다.

**CASE 1**

```json
"NUTR_CONT7": "N/A"
```

**CASE 2**

```json
"NUTR_CONT7": "0.00"
```

내린 결론은 직접 파싱하는 일이었다.

```java
private Double parseDouble(JsonNode node) {  
	if ("N/A".equals(node.asText())) {  
		return null;  
	}  
	return node.asDouble();  
}
```

다음 코드에서 각 필드마다 검증하고 있다.

```java
public class CustomItemDeserializer extends JsonDeserializer<FoodNtrIrdntInfoResponseItem> {  
	@Override  
	public FoodNtrIrdntInfoResponseItem deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {  
		var node = (JsonNode) p.getCodec().readTree(p);  
		return new FoodNtrIrdntInfoResponseItem(  
			...
			parseDouble(getField(node, SERVING_SIZE_GRAM)),  
			...
		);  
	}
...
}
```

### 이슈번호 첨부,  기타내용

- [Projects - 공공데이터에서 데이터를 추출한다.](https://github.com/orgs/towards-sweetly/projects/1?pane=issue&itemId=33293668)
