### PR TITLE
공공 데이터를 조회할 때 필요한 프로퍼티 주입 방식을 변경한다.

### DIFF
--- a/src/main/java/towardssweetly/datascheduler/config/FoodNtrIrdntInfoApiConfiguration.java
+++ b/src/main/java/towardssweetly/datascheduler/config/FoodNtrIrdntInfoApiConfiguration.java
@@ -1,0 +1,22 @@
+package towardssweetly.datascheduler.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class FoodNtrIrdntInfoApiConfiguration {
+    private final String serviceKey;
+    private final String url;
+
+    public FoodNtrIrdntInfoApiConfiguration(
+            @Value("${api.foodNtrIrdntInfoService.service-key}")
+            String serviceKey,
+            @Value("${api.foodNtrIrdntInfoService.url}")
+            String url
+    ) {
+        this.serviceKey = serviceKey;
+        this.url = url;
+    }
+}

--- a/src/main/java/towardssweetly/datascheduler/infra/FoodNtrIrdntInfoService.java
+++ b/src/main/java/towardssweetly/datascheduler/infra/FoodNtrIrdntInfoService.java
@@ -6,6 +6,7 @@ import org.springframework.http.RequestEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+import towardssweetly.datascheduler.config.FoodNtrIrdntInfoApiConfiguration;
 import towardssweetly.datascheduler.infra.dto.FoodNtrIrdntInfoResponse;
 
 /**
@@ -20,17 +21,18 @@ import towardssweetly.datascheduler.infra.dto.FoodNtrIrdntInfoResponse;
  */
 @Service
 public class FoodNtrIrdntInfoService {
-    private static final String URL = "https://apis.data.go.kr/1471000/FoodNtrIrdntInfoService1/getFoodNtrItdntList1";
     private final RestTemplate restTemplate;
+    private final FoodNtrIrdntInfoApiConfiguration configuration;
 
-    public FoodNtrIrdntInfoService(RestTemplateBuilder builder) {
+    public FoodNtrIrdntInfoService(RestTemplateBuilder builder, FoodNtrIrdntInfoApiConfiguration configuration) {
         this.restTemplate = builder.build();
+        this.configuration = configuration;
     }
 
-    public FoodNtrIrdntInfoResponse getFoodNtrIrdntInfoResponse(int pageNo, int numOfRows, String type, String serviceKey) {
-        final var uri = UriComponentsBuilder.fromUriString(URL)
+    public FoodNtrIrdntInfoResponse getFoodNtrIrdntInfoResponse(int pageNo, int numOfRows, String type) {
+        final var uri = UriComponentsBuilder.fromUriString(configuration.getUrl())
                 .queryParam("pageNo", pageNo)
-                .queryParam("serviceKey", serviceKey)
+                .queryParam("serviceKey", configuration.getServiceKey())
                 .queryParam("numOfRows", numOfRows)
                 .queryParam("type", type)
                 .encode()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-
+api.foodNtrIrdntInfoService.service-key=1cM0fca7x9v9lVDH7x/Ys0Sg9uzmVsLqRY/yRtnbxpefDmZHVQf2zdR768cNW8Qrx5GlwWK0RyMa2ekGH4bJSg==
+api.foodNtrIrdntInfoService.url=https://apis.data.go.kr/1471000/FoodNtrIrdntInfoService1/getFoodNtrItdntList1

--- a/src/test/java/towardssweetly/datascheduler/infra/FoodNtrIrdntInfoServiceTest.java
+++ b/src/test/java/towardssweetly/datascheduler/infra/FoodNtrIrdntInfoServiceTest.java
@@ -1,15 +1,20 @@
 package towardssweetly.datascheduler.infra;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import towardssweetly.datascheduler.config.FoodNtrIrdntInfoApiConfiguration;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
+@SpringBootTest
 class FoodNtrIrdntInfoServiceTest {
-    private static final String SERVICE_KEY = "1cM0fca7x9v9lVDH7x/Ys0Sg9uzmVsLqRY/yRtnbxpefDmZHVQf2zdR768cNW8Qrx5GlwWK0RyMa2ekGH4bJSg==";
-    private final FoodNtrIrdntInfoService foodNtrIrdntInfoService = new FoodNtrIrdntInfoService(new RestTemplateBuilder());
+    @Autowired
+    FoodNtrIrdntInfoApiConfiguration configuration;
+
+    @Autowired
+    private FoodNtrIrdntInfoService foodNtrIrdntInfoService;
 
     @Test
     @DisplayName("https://apis.data.go.kr 주소에 실제 데이터를 요청한다.")
@@ -17,7 +22,7 @@ class FoodNtrIrdntInfoServiceTest {
         final var json = "json";
         final var pageNo = 1;
         final var numOfRows = 10;
-        final var response = foodNtrIrdntInfoService.getFoodNtrIrdntInfoResponse(pageNo, numOfRows, json, SERVICE_KEY);
+        final var response = foodNtrIrdntInfoService.getFoodNtrIrdntInfoResponse(pageNo, numOfRows, json);
         assertThat(response.getBody().getItems().size()).isEqualTo(numOfRows);
     }
 }


### PR DESCRIPTION
### Description

공공 데이터를 조회할 때 필요한 프로퍼티를 코드 상에 추가했지만, 테스트를 할 때 중복된 코드를 작성할 필요가 있다. 그렇기에 필요한 프로퍼티를 외부로 분리한 후 의존성을 주입할 수 있도록 구성했다.

프로퍼티를 주입하는 방식은 생성자를 활용해 프로퍼티를 사용하는 입장에서는 불변 데이터를 사용할 수 있도록 신뢰성을 높였다.

```java
public class FoodNtrIrdntInfoApiConfiguration {
    private final String serviceKey;
    private final String url;

    public FoodNtrIrdntInfoApiConfiguration(
            @Value("${api.foodNtrIrdntInfoService.service-key}")
            String serviceKey,
            @Value("${api.foodNtrIrdntInfoService.url}")
            String url
    ) {
        this.serviceKey = serviceKey;
        this.url = url;
    }
}

```

프로퍼티 주입으로 변경됨에 따라 테스트 코드 구성도 달라졌다. `application.properties`에 저장된 데이터를 활용하기 위해 `@SpringBootTest` 애너테이션을 추가했다. `@SpringBootTest` 애너테이션을 활용한 문제로 로딩 시간이 길어졌지만, 테스트 코드 양이 적어 괜찮다고 생각했고, 테스트 코드에서 의존 주입을 할 경우 코드가 늘어나 관리할 영역이 커지는 것을 우려했다.

```java
@SpringBootTest
class FoodNtrIrdntInfoServiceTest {
    @Autowired
    FoodNtrIrdntInfoApiConfiguration configuration;

    @Autowired
    private FoodNtrIrdntInfoService foodNtrIrdntInfoService;

    @Test
    @DisplayName("https://apis.data.go.kr 주소에 실제 데이터를 요청한다.")
    void getFoodNtrIrdntInfoResponseTest() {
        final var json = "json";
        final var pageNo = 1;
        final var numOfRows = 10;
        final var response = foodNtrIrdntInfoService.getFoodNtrIrdntInfoResponse(pageNo, numOfRows, json);
        assertThat(response.getBody().getItems().size()).isEqualTo(numOfRows);
    }
}
```

현재는 application.properties에 필요한 데이터가 저장되지만 다음처럼 외부에서 주입해 관리할 수 있다.

**대안 1**

Github에 private repo를 개설하고 properties 파일을 생성한 후 git에서 제공하는 서브 모듈을 활용한다.

**대안 2**

Git Action으로 스케줄링할 때, 프로퍼티를 추가한다. 프로퍼티를 관리하는 위치는 Github의 Secrets로 관리한다.

```shell
java -jar -D=api.foodNtrIrdntInfoService.service-key={key} D=api.foodNtrIrdntInfoService.url={url}
```